### PR TITLE
Fix path in `formats/plain/plain-no-date.tex`

### DIFF
--- a/formats/plain/plain-no-date.tex
+++ b/formats/plain/plain-no-date.tex
@@ -1,2 +1,2 @@
 \newcommand{\writedate}{}
-\input{styles/plain/plain}
+\input{formats/plain/plain}


### PR DESCRIPTION
Update path from `\input{styles/plain/plain}` to `\input{formats/plain/plain}` to fix compilation error. 