### PR TITLE
feat: Add support for specifying a short title for the ACM format

### DIFF
--- a/formats/acm/acm.tex
+++ b/formats/acm/acm.tex
@@ -2,7 +2,11 @@
 \newcommand{\preabstract}{
 
     % Set the title
-    \title{\papertitle}
+    \ifcsname shortpapertitle\endcsname
+        \title[\shortpapertitle]{\papertitle}
+    \else
+        \title{\papertitle}
+    \fi
 
     % Define the author block
     \ifcsname doubleblind\endcsname
@@ -41,7 +45,7 @@
             \affiliation{
                 \institution{\lastauthoraffiliation}
                 \country{\lastauthorcountry}
-            }            
+            }
         \fi
     \fi
 

--- a/formats/acm/conference.tex
+++ b/formats/acm/conference.tex
@@ -5,7 +5,11 @@
 \newcommand{\preabstract}{
 
     % Set the title
-    \title{\papertitle}
+    \ifcsname shortpapertitle\endcsname
+        \title[\shortpapertitle]{\papertitle}
+    \else
+        \title{\papertitle}
+    \fi
 
     % Define the author block
     \ifcsname doubleblind\endcsname
@@ -44,7 +48,7 @@
             \affiliation{
                 \institution{\lastauthoraffiliation}
                 \country{\lastauthorcountry}
-            }            
+            }
         \fi
     \fi
 

--- a/paper.tex
+++ b/paper.tex
@@ -2,6 +2,7 @@
 
 % Set the title of the paper
 \newcommand{\papertitle}{A New Paper}
+%\newcommand{\shortpapertitle}{A New, Short Paper}
 
 % Include details of the authors 
 \input{authors}


### PR DESCRIPTION
Use the optional `\shortpapertitle` command to specify a short title for the paper that gets displayed in the header in the ACM formats.